### PR TITLE
ci: include token permissions needed to create artifact content of a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Upload
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning][semver].
 
 - Upload reports of test coverage to Codecov to complete proofs of concept.
 - Save compilations for various machines to releases when tags are created.
+- Include token permissions needed to create artifact content of a release.
 
 ## [0.1.0] - 2025-05-03
 


### PR DESCRIPTION
📚 https://goreleaser.com/quick-start/

> To release to GitHub, you'll need to export a `GITHUB_TOKEN` environment variable, which should contain a valid GitHub token with the `repo` scope. It will be used to deploy releases to your GitHub repository. You can create a new GitHub token [here](https://github.com/settings/tokens/new?scopes=repo,write:packages).

> The minimum permissions the `GITHUB_TOKEN` should have to run this are `write:packages`

```
  ⨯ release failed after 18s                 error=scm releases: failed to publish artifacts: could not release: POST https://api.github.com/repos/zimeg/git-coverage/releases: 403 Resource not accessible by integration []
```

https://github.com/zimeg/git-coverage/actions/runs/14818431455/job/41602083658#step:4:183

🔍 https://github.com/goreleaser/example-zig/blob/6bfeba3587e169ff31cba2da32854da025600937/.github/workflows/release.yml#L10-L11