### PR TITLE
ci: confirm code formatting matches the standard expectations about language

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v17
       - name: Run tests
         run: |
+          shopt -s globstar
           nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build test -Dcoverage
       - name: Upload reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v17
       - name: Run tests
         run: |
+          nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build test -Dcoverage
       - name: Upload reports
         uses: codecov/codecov-action@v5.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Maintenance
+
+- Confirm code formatting matches the standard expectations about language.
+
 ## [0.1.1] - 2025-05-03
 
 ### Maintenance

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
         .allocator = allocator,
         .argv = &[_][]const u8{ "open", url },
     }) catch {
-        try std.io.getStdOut().writer().print("{s}\n", .{ url });
+        try std.io.getStdOut().writer().print("{s}\n", .{url});
     };
 }
 
@@ -29,7 +29,7 @@ fn origin(remotes: []const u8) ![]const u8 {
         const line = remote.next();
         if (line) |val| {
             if (std.mem.startsWith(u8, val, "origin") and std.mem.endsWith(u8, val, "(push)")) {
-                return std.mem.trim(u8, val[7..val.len-6], " ");
+                return std.mem.trim(u8, val[7 .. val.len - 6], " ");
             }
         } else {
             return error.GitOriginMissing;
@@ -51,10 +51,10 @@ test "origin ssh" {
 
 fn repo(remote: []const u8) ![]const u8 {
     if (std.mem.startsWith(u8, remote, "https://github.com/")) {
-        return remote[19..remote.len-4];
+        return remote[19 .. remote.len - 4];
     }
     if (std.mem.startsWith(u8, remote, "git@github.com:")) {
-        return remote[15..remote.len-4];
+        return remote[15 .. remote.len - 4];
     }
     return error.GitProtocolMissing;
 }
@@ -75,7 +75,7 @@ fn coverage(allocator: std.mem.Allocator, project: []const u8) ![]const u8 {
     return std.fmt.allocPrint(
         allocator,
         "https://app.codecov.io/gh/{s}",
-        .{ project },
+        .{project},
     );
 }
 


### PR DESCRIPTION
```
$ zig fmt ./src/**/*.zig
```

🤖