### PR TITLE
feat: pick an upstream project according to the saved git remotes using a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning][semver].
 - Print usage details to standard output if a help flag is used in command.
 - Document more detailed usage with manual pages for even better reference.
 - Include installation instruction for moving a release download into path.
+- Pick an upstream project according to the saved git remotes using a flag.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ git coverage  # https://app.codecov.io/gh/zimeg/git-coverage
 Options are available for customization:
 
 - `--help`: boolean. Print these usage details. Default: `false`
+- `--remote`: string. Pick an upstream project. Default: `origin`
 
 ## Installation
 

--- a/man/git-coverage.1
+++ b/man/git-coverage.1
@@ -17,6 +17,8 @@ The \fBgit-coverage\fP program opens test coverage results uploaded to \fBcodeco
 .
 .IP "-h, --help"
 Print these usage details.
+.IP "--remote"
+Pick an upstream project. Default: "origin"
 .
 .
 .SH EXIT STATUS


### PR DESCRIPTION
```
$ git coverage --remote upstream
```

👾