### PR TITLE
ci: limit the permission set to the minimum required for all action workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ jobs:
   test:
     name: Report
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Maintenance
+
+- Limit the permission set to the minimum required for all action workflow.
+
 ## [0.2.0] - 2025-05-10
 
 ### Added


### PR DESCRIPTION
https://github.com/zimeg/git-coverage/security/code-scanning/1 🤖