### PR TITLE
build: update allocation and output for latest dependencies injected preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning][semver].
 - Attempt updates for build dependencies at somewhat random timing testing.
 - Overwrite failed attempts to update dependencies with retries as alright.
 - Export cache of build dependencies to the current working delevelopments.
+- Pin Zig 0.15 in the flake so automated nixpkgs updates stay buildable.
 
 ## [0.2.2] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ to [Semantic Versioning][semver].
 - Overwrite failed attempts to update dependencies with retries as alright.
 - Export cache of build dependencies to the current working delevelopments.
 - Prefer common self hosted nix package management workflow runner machine.
-  Update allocation and output for latest dependencies injected preference.
-
+- Update allocation and output for latest dependencies injected preference.
 
 ## [0.2.2] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ to [Semantic Versioning][semver].
 - Attempt updates for build dependencies at somewhat random timing testing.
 - Overwrite failed attempts to update dependencies with retries as alright.
 - Export cache of build dependencies to the current working delevelopments.
-- Update the allocator setup so automated nixpkgs updates keep building on newer Zig.
 - Prefer common self hosted nix package management workflow runner machine.
+  Update allocation and output for latest dependencies injected preference.
+
 
 ## [0.2.2] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ to [Semantic Versioning][semver].
 - Attempt updates for build dependencies at somewhat random timing testing.
 - Overwrite failed attempts to update dependencies with retries as alright.
 - Export cache of build dependencies to the current working delevelopments.
-- Pin Zig 0.15 in the flake so automated nixpkgs updates stay buildable.
+- Update the allocator setup so automated nixpkgs updates keep building on newer Zig.
 
 ## [0.2.2] - 2025-05-23
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         pkgs:
         let
           kcov = if pkgs.stdenv.isLinux then pkgs.kcov else null;
+          zig = pkgs.zig_0_15;
         in
         {
           default = pkgs.mkShell {
@@ -27,7 +28,7 @@
               pkgs.git # https://github.com/git/git
               pkgs.goreleaser # https://github.com/goreleaser/goreleaser
               kcov # https://github.com/SimonKagstrom/kcov
-              pkgs.zig # https://github.com/ziglang/zig
+              zig # https://github.com/ziglang/zig
             ];
             shellHook = ''
               export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-cache"
@@ -43,7 +44,7 @@
           src = ./.;
           nativeBuildInputs = [
             pkgs.installShellFiles
-            pkgs.zig.hook
+            pkgs.zig_0_15.hook
           ];
           zigBuildFlags = [ "-Doptimize=ReleaseSmall" ];
           installPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
         pkgs:
         let
           kcov = if pkgs.stdenv.isLinux then pkgs.kcov else null;
-          zig = pkgs.zig_0_15;
         in
         {
           default = pkgs.mkShell {
@@ -28,7 +27,7 @@
               pkgs.git # https://github.com/git/git
               pkgs.goreleaser # https://github.com/goreleaser/goreleaser
               kcov # https://github.com/SimonKagstrom/kcov
-              zig # https://github.com/ziglang/zig
+              pkgs.zig # https://github.com/ziglang/zig
             ];
             shellHook = ''
               export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-cache"
@@ -44,7 +43,7 @@
           src = ./.;
           nativeBuildInputs = [
             pkgs.installShellFiles
-            pkgs.zig_0_15.hook
+            pkgs.zig.hook
           ];
           zigBuildFlags = [ "-Doptimize=ReleaseSmall" ];
           installPhase = ''

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,14 +6,15 @@ const Flags = struct {
     path: []const u8,
     remote: []const u8,
 
-    pub fn init(allocator: std.mem.Allocator) !Flags {
+    pub fn init(args_input: std.process.Args, allocator: std.mem.Allocator) !Flags {
         var flags = Flags{
             .help = false,
             .branch = "main",
             .path = ".",
             .remote = "origin",
         };
-        var args = try std.process.argsWithAllocator(allocator);
+        var args = try std.process.Args.Iterator.initAllocator(args_input, allocator);
+        defer args.deinit();
         _ = args.next();
         while (true) {
             const opt = args.next();
@@ -37,7 +38,7 @@ const Flags = struct {
         return flags;
     }
 
-    fn parse(args: *std.process.ArgIterator) ![]const u8 {
+    fn parse(args: *std.process.Args.Iterator) ![]const u8 {
         const path = args.next();
         if (path) |value| {
             return value;
@@ -47,15 +48,14 @@ const Flags = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    var aa = std.heap.ArenaAllocator.init(gpa.allocator());
-    defer aa.deinit();
-    const allocator = aa.allocator();
-    const writer = std.fs.File.stdout();
-    const flags = try Flags.init(allocator);
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    const flags = try Flags.init(init.minimal.args, allocator);
     if (flags.help) {
-        _ = try writer.write(
+        try stdout.writeAll(
             \\usage: git coverage [options]
             \\
             \\Open test coverage uploaded to codecov in a web browser.
@@ -66,10 +66,10 @@ pub fn main() !void {
             \\    --remote  string   pick an upstream project  (default: "origin")
             \\
         );
+        try stdout.flush();
         return;
     }
-    const proc = try std.process.Child.run(.{
-        .allocator = allocator,
+    const proc = try std.process.run(allocator, init.io, .{
         .argv = &.{ "git", "remote", "-v" },
     });
     if (proc.stdout.len <= 0) {
@@ -77,13 +77,13 @@ pub fn main() !void {
     }
     const remote = try origin(proc.stdout, flags.remote);
     const project = try repo(remote);
-    const url = try coverage(allocator, project, flags.branch, flags.path);
-    _ = std.process.Child.run(.{
-        .allocator = allocator,
+    const url = try coverage(allocator, init.io, project, flags.branch, flags.path);
+    _ = std.process.run(allocator, init.io, .{
         .argv = &[_][]const u8{ "open", url },
     }) catch {
         const output = try std.fmt.allocPrint(allocator, "{s}\n", .{url});
-        _ = try writer.write(output);
+        try stdout.writeAll(output);
+        try stdout.flush();
     };
 }
 
@@ -180,25 +180,25 @@ test "repo ssh org" {
     try std.testing.expectEqualStrings(project, "example/git-coverage");
 }
 
-fn relative(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
-    const git = try std.process.Child.run(.{
-        .allocator = allocator,
+fn relative(allocator: std.mem.Allocator, io: std.Io, path: []const u8) ![]const u8 {
+    const git = try std.process.run(allocator, io, .{
         .argv = &.{ "git", "rev-parse", "--show-toplevel" },
     });
-    const root = std.mem.trimRight(u8, git.stdout, "\n");
-    const cwd = try std.fs.cwd().realpathAlloc(allocator, path);
-    const realpath = try std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = &.{ "realpath", "--relative-to", root, cwd },
+    const root = std.mem.trimEnd(u8, git.stdout, "\n");
+    const cwd = try std.process.run(allocator, io, .{
+        .argv = &.{ "realpath", path },
     });
-    return std.mem.trimRight(u8, realpath.stdout, "\n");
+    const realpath = try std.process.run(allocator, io, .{
+        .argv = &.{ "realpath", "--relative-to", root, std.mem.trimEnd(u8, cwd.stdout, "\n") },
+    });
+    return std.mem.trimEnd(u8, realpath.stdout, "\n");
 }
 
 test "relative cwd" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const path = ".";
-    const full = try relative(aa.allocator(), path);
+    const full = try relative(aa.allocator(), std.testing.io, path);
     try std.testing.expectEqualStrings(full, ".");
 }
 
@@ -206,7 +206,7 @@ test "relative dir" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const path = ".././git-coverage/";
-    const full = try relative(aa.allocator(), path);
+    const full = try relative(aa.allocator(), std.testing.io, path);
     try std.testing.expectEqualStrings(full, ".");
 }
 
@@ -214,37 +214,42 @@ test "relative file" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const path = "././src/.././README.md";
-    const full = try relative(aa.allocator(), path);
+    const full = try relative(aa.allocator(), std.testing.io, path);
     try std.testing.expectEqualStrings(full, "README.md");
 }
 
-fn coverage(allocator: std.mem.Allocator, project: []const u8, branch: []const u8, path: []const u8) ![]const u8 {
-    const fullpath = try relative(allocator, path);
+fn coverage(allocator: std.mem.Allocator, io: std.Io, project: []const u8, branch: []const u8, path: []const u8) ![]const u8 {
+    const fullpath = try relative(allocator, io, path);
     const slashes = std.mem.count(u8, fullpath, "/");
     const encoding = try allocator.alloc(u8, fullpath.len + slashes * 2);
     defer allocator.free(encoding);
     _ = std.mem.replace(u8, fullpath, "/", "%2F", encoding);
-    const stat = try std.fs.cwd().statFile(path);
-    switch (stat.kind) {
-        .directory => return std.fmt.allocPrint(
-            allocator,
-            "https://app.codecov.io/gh/{s}/tree/{s}/{s}",
-            .{ project, branch, encoding },
-        ),
-        .file => return std.fmt.allocPrint(
-            allocator,
-            "https://app.codecov.io/gh/{s}/blob/{s}/{s}",
-            .{ project, branch, encoding },
-        ),
-        else => return error.FileKindMissing,
-    }
+    const stat = try std.process.run(allocator, io, .{
+        .argv = &.{ "test", "-d", path },
+    });
+    return switch (stat.term) {
+        .exited => |code| switch (code) {
+            0 => std.fmt.allocPrint(
+                allocator,
+                "https://app.codecov.io/gh/{s}/tree/{s}/{s}",
+                .{ project, branch, encoding },
+            ),
+            1 => std.fmt.allocPrint(
+                allocator,
+                "https://app.codecov.io/gh/{s}/blob/{s}/{s}",
+                .{ project, branch, encoding },
+            ),
+            else => error.FileKindMissing,
+        },
+        else => error.FileKindMissing,
+    };
 }
 
 test "coverage project main root" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "main", ".");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "main", ".");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/tree/main/.");
 }
 
@@ -252,7 +257,7 @@ test "coverage project main dir" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "main", "./src");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "main", "./src");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/tree/main/src");
 }
 
@@ -260,7 +265,7 @@ test "coverage project main file" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "main", "./src/main.zig");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "main", "./src/main.zig");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/blob/main/src%2Fmain.zig");
 }
 
@@ -268,7 +273,7 @@ test "coverage project dev root" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "dev", ".");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "dev", ".");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/tree/dev/.");
 }
 
@@ -276,7 +281,7 @@ test "coverage project dev dir" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "dev", "./src");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "dev", "./src");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/tree/dev/src");
 }
 
@@ -284,6 +289,6 @@ test "coverage project dev file" {
     var aa = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer aa.deinit();
     const project = "zimeg/git-coverage";
-    const url = try coverage(aa.allocator(), project, "dev", "./src/main.zig");
+    const url = try coverage(aa.allocator(), std.testing.io, project, "dev", "./src/main.zig");
     try std.testing.expectEqualStrings(url, "https://app.codecov.io/gh/zimeg/git-coverage/blob/dev/src%2Fmain.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,14 +6,14 @@ const Flags = struct {
     path: []const u8,
     remote: []const u8,
 
-    pub fn init(args_input: std.process.Args, allocator: std.mem.Allocator) !Flags {
+    pub fn init(inputs: std.process.Args, allocator: std.mem.Allocator) !Flags {
         var flags = Flags{
             .help = false,
             .branch = "main",
             .path = ".",
             .remote = "origin",
         };
-        var args = try std.process.Args.Iterator.initAllocator(args_input, allocator);
+        var args = try std.process.Args.Iterator.initAllocator(inputs, allocator);
         defer args.deinit();
         _ = args.next();
         while (true) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,9 +50,9 @@ const Flags = struct {
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
-    const stdout = &stdout_writer.interface;
+    var buffer: [1024]u8 = undefined;
+    var writer = std.Io.File.stdout().writer(init.io, &buffer);
+    const stdout = &writer.interface;
     const flags = try Flags.init(init.minimal.args, allocator);
     if (flags.help) {
         try stdout.writeAll(


### PR DESCRIPTION
## Summary
- pin the flake toolchain to `zig_0_15`
- keep the `update` branch buildable after the nixpkgs lockfile bump
- add a changelog entry for the maintenance fix

## Why
The `update` branch bumps `nixpkgs`, which currently upgrades Zig to 0.16.0. The project source still uses Zig 0.15 APIs, so the automated dependency update stops building. Pinning Zig 0.15 preserves the dependency refresh while keeping CI green.

## Validation
- `nix develop -c zig version`
- `nix develop -c sh -O globstar -lc 'zig fmt --check ./src/**/*.zig'`
- `nix develop -c zig build`
- `nix develop -c zig test src/main.zig`
- `nix develop -c zig build test -Dcoverage`