### PR TITLE
ci: use tom runner label for self-hosted jobs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -31,8 +31,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Start the tests
         run: |
           gh api \
@@ -73,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -87,8 +85,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Checkout an update
         run: |
           git checkout -b update

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: self-hosted
+    runs-on: tom
     timeout-minutes: 12
     permissions:
       actions: write
@@ -71,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Upload
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       packages: write
@@ -17,8 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Publish artifacts
         run: |
           nix develop -c goreleaser release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Upload
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           nix develop -c zig build test -Dcoverage
       - name: Locate the codecov binary
         id: codecov
-        run: echo "binary=$(nix build nixpkgs#codecov-cli --no-link --print-out-paths)/bin/codecovcli" >> "$GITHUB_OUTPUT"
+        run: echo "binary=$(which codecovcli)" >> "$GITHUB_OUTPUT"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build
           nix develop -c zig build test -Dcoverage
-      - name: Locate the codecov binary
+      - name: Locate Codecov
         id: codecov
         run: echo "binary=$(command -v codecovcli)" >> "$GITHUB_OUTPUT"
       - name: Upload reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,6 @@ jobs:
           binary: ${{ steps.codecov.outputs.binary }}
           fail_ci_if_error: true
           override_commit: ${{ github.sha }}
-          override_slug: ${{ github.repository }}
+          slug: ${{ github.repository }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,13 @@ jobs:
           nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build
           nix develop -c zig build test -Dcoverage
+      - name: Locate the codecov binary
+        id: codecov
+        run: echo "binary=$(nix build nixpkgs#codecov-cli --no-link --print-out-paths)/bin/codecovcli" >> "$GITHUB_OUTPUT"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          binary: ${{ steps.codecov.outputs.binary }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Report
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           nix develop -c zig build test -Dcoverage
       - name: Locate the codecov binary
         id: codecov
-        run: echo "CC_BINARY=$(which codecovcli)" >> "$GITHUB_ENV"
+        run: echo "CC_BINARY=$(command -v codecovcli)" >> "$GITHUB_ENV"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,13 @@ jobs:
           nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build
           nix develop -c zig build test -Dcoverage
+      - name: Locate the codecov binary
+        id: codecov
+        run: echo "binary=$(command -v codecovcli)" >> "$GITHUB_OUTPUT"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          binary: codecovcli
+          binary: ${{ steps.codecov.outputs.binary }}
           fail_ci_if_error: true
           override_commit: ${{ github.sha }}
           override_slug: ${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,12 @@ jobs:
           nix develop -c zig fmt --check ./src/**/*.zig
           nix develop -c zig build
           nix develop -c zig build test -Dcoverage
-      - name: Locate the codecov binary
-        id: codecov
-        run: echo "CC_BINARY=$(command -v codecovcli)" >> "$GITHUB_ENV"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          binary: ${{ env.CC_BINARY }}
+          binary: codecovcli
           fail_ci_if_error: true
           override_commit: ${{ github.sha }}
+          override_slug: ${{ github.repository }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Report
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Run tests
         run: |
           shopt -s globstar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,6 @@ jobs:
         with:
           binary: ${{ env.CC_BINARY }}
           fail_ci_if_error: true
+          override_commit: ${{ github.sha }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
           nix develop -c zig build test -Dcoverage
       - name: Locate the codecov binary
         id: codecov
-        run: echo "binary=$(which codecovcli)" >> "$GITHUB_OUTPUT"
+        run: echo "CC_BINARY=$(which codecovcli)" >> "$GITHUB_ENV"
       - name: Upload reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          binary: ${{ steps.codecov.outputs.binary }}
+          binary: ${{ env.CC_BINARY }}
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning][semver].
 ## [Unreleased]
 
 ### Maintenance
+- Migrate nix dependent workflows to use self hosted runner machines.
 
 - Remove additional utilities from flake packaging for small installations.
 - Write to standard output file descriptors using zig string format method.


### PR DESCRIPTION
Updates self-hosted runner references to use the `tom` label.